### PR TITLE
Update MGSM2Fix.ini

### DIFF
--- a/MGSM2Fix.ini
+++ b/MGSM2Fix.ini
@@ -10,8 +10,14 @@ Windowed = false
 Borderless = false
 
 [Internal Resolution]
-; MGS1 only: Enables render resolution scaling.
-; Width is controlled using the in-game settings. Leave the height at 0 to use the external resolution.
+; MGS1 only: Enables render resolution scaling
+; What most people would call a "4K mod" or a resolution upscaler.
+; Only height is needed - width is set intrinsically by the game.
+; Leave the height at 0 if you wish to use the external resolution.
+;
+; Additionally, set Widescreen to 'true' to enable proper widescreen without horizontal stretching.
+; (Note: the in-game settings must also be set to 'Widescreen' for this to take effect, and won't kick in until you exit the settings menu)
+; 
 Enabled = false
 Height = 0
 Widescreen = false
@@ -19,8 +25,8 @@ Widescreen = false
 [Launcher]
 ; Skips the warnings / logos on start.
 SkipNotice = true
-; MGS1 only: Starts the game directly with the previously saved settings and game version.
-; You can change those options by going back to the main menu via the pause menu.
+; MGS1 only: Starts the game directly with the previously saved settings and game version
+; Change the game version/settings by going back to the game selection menu via the in-game pause menu
 StartGame = false
 
 [Patches]
@@ -33,9 +39,11 @@ RestoreGhosts = true
 ; MGS1 only: Reverts the Master Collection texture swaps for medicine items.
 RestoreMedicine = true
 
-; MGS1 only: Advanced option, master toggle for *all* RAM patches.
+; MGS1 only: ! ADVANCED OPTION !  Master toggle for *all* RAM patches.
+; May interfere with achievements!
 DisableRAM = false
-; MGS1 only: Advanced option, master toggle for *all* CD-ROM patches.
+; MGS1 only: ! ADVANCED OPTION !  Master toggle for *all* CD-ROM patches.
+; May interfere with achievements!
 DisableCDROM = false
 
 [Game]


### PR DESCRIPTION
added verbosity to technical descriptions and functions, particularly for the internal resolution scaler

added some verbosity to the launcher skip functionality

added warnings to RAM patch functionality description regarding achievements