### PR TITLE
Fixes monitors going to sleep during long cutscenes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This is a fix that adds custom resolutions, mod support and more to Metal Gear S
 ## Features
 - Custom internal render resolution & widescreen support (MGS1).
 - Borderless/windowed mode.
+- Corrects the monitor going to sleep during long periods with no input (e.g. during cutscenes.)
 - Control over built-in filters and Master Collection game patches.
 - ~~Analog input (MGS1).~~ - Fixed by Konami officially via patch 1.5.0 on 13MAR2024
 - Launcher skip (MGS1, boots last launched game version).

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -1274,6 +1274,7 @@ BOOL APIENTRY DllMain( HMODULE hModule,
             SetThreadPriority(mainHandle, THREAD_PRIORITY_HIGHEST); // set our Main thread priority higher than the games thread
             CloseHandle(mainHandle);
         }
+        SetThreadExecutionState(ES_CONTINUOUS | ES_SYSTEM_REQUIRED | ES_DISPLAY_REQUIRED); //fixes the monitor going to sleep during cutscenes.
     }
     case DLL_THREAD_ATTACH:
     case DLL_THREAD_DETACH:


### PR DESCRIPTION
Haven't tested with M2 specifically since I can't compile, but it's the same fix used for [MGSHDFix](https://github.com/Lyall/MGSHDFix/pull/127) & should be universal for all windows apps.

(to confirm, open powershell as admin & run `powercfg -requests` while the game is running & `METAL GEAR SOLID.exe`/whatever game it's installed for should be present under display.)