### PR TITLE
Fixes steam deck / steamos version detection

### DIFF
--- a/src/m2utils.h
+++ b/src/m2utils.h
@@ -21,4 +21,6 @@ public:
 	static std::condition_variable mainThreadFinishedVar;
 	static bool mainThreadFinished;
 
+	static bool IsSteamOS();
+	static std::string GetSteamOSVersion();
 };


### PR DESCRIPTION
fixes the proton wrapper being logged as windows 10

old;
![image](https://github.com/user-attachments/assets/b7a792de-5cf6-4321-806a-72676a8b06c3)

new;
![image](https://github.com/user-attachments/assets/f79b1191-6be1-4073-89d6-5a6e6dad3e48)
