### PR TITLE
Moves zydis to a prebuild event

### DIFF
--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -13,6 +13,21 @@ jobs:
       with:
         submodules: recursive
         
+    - name: Get Zydis submodule hash
+      id: zydishash
+      run: |
+        cd src/zydis
+        $hash = git rev-parse HEAD
+        "hash=$hash" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
+    - name: Cache Zydis
+      uses: actions/cache@v4
+      with:
+        path: |
+          src/zydis/msvc/bin/ReleaseX64
+          src/zydis/msvc/bin/ReleaseX86
+        key: zydis-${{ runner.os }}-${{ steps.zydishash.outputs.hash }}
+
     - name: Install Python dependencies
       uses: py-actions/py-dependency-install@v4
       

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -24,6 +24,21 @@ jobs:
     - name: Install Python dependencies
       uses: py-actions/py-dependency-install@v4
 
+    - name: Get Zydis submodule hash
+      id: zydishash
+      run: |
+        cd src/zydis
+        $hash = git rev-parse HEAD
+        "hash=$hash" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
+    - name: Cache Zydis
+      uses: actions/cache@v4
+      with:
+        path: |
+          src/zydis/msvc/bin/ReleaseX64
+          src/zydis/msvc/bin/ReleaseX86
+        key: zydis-${{ runner.os }}-${{ steps.zydishash.outputs.hash }}
+
     - name: Download ASI Loader x64
       uses: robinraju/release-downloader@v1.8
       with:

--- a/MGSM2Fix.sln
+++ b/MGSM2Fix.sln
@@ -4,11 +4,6 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 VisualStudioVersion = 17.3.32901.215
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "MGSM2Fix", "MGSM2Fix.vcxproj", "{C6644269-B721-4F94-BE7F-77BFB2343BA5}"
-	ProjectSection(ProjectDependencies) = postProject
-		{88A23124-5640-35A0-B890-311D7A67A7D2} = {88A23124-5640-35A0-B890-311D7A67A7D2}
-	EndProjectSection
-EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Zydis", "src\zydis\msvc\zydis\Zydis.vcxproj", "{88A23124-5640-35A0-B890-311D7A67A7D2}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -30,14 +25,6 @@ Global
 		{C6644269-B721-4F94-BE7F-77BFB2343BA5}.Release|x86.ActiveCfg = Release|Win32
 		{C6644269-B721-4F94-BE7F-77BFB2343BA5}.Release|x86.Build.0 = Release|Win32
 		{C6644269-B721-4F94-BE7F-77BFB2343BA5}.Release|x86.Deploy.0 = Release|Win32
-		{88A23124-5640-35A0-B890-311D7A67A7D2}.Debug|x64.ActiveCfg = Release MT|x64
-		{88A23124-5640-35A0-B890-311D7A67A7D2}.Debug|x64.Build.0 = Release MT|x64
-		{88A23124-5640-35A0-B890-311D7A67A7D2}.Debug|x86.ActiveCfg = Release MT|Win32
-		{88A23124-5640-35A0-B890-311D7A67A7D2}.Debug|x86.Build.0 = Release MT|Win32
-		{88A23124-5640-35A0-B890-311D7A67A7D2}.Release|x64.ActiveCfg = Release MT|x64
-		{88A23124-5640-35A0-B890-311D7A67A7D2}.Release|x64.Build.0 = Release MT|x64
-		{88A23124-5640-35A0-B890-311D7A67A7D2}.Release|x86.ActiveCfg = Release MT|Win32
-		{88A23124-5640-35A0-B890-311D7A67A7D2}.Release|x86.Build.0 = Release MT|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/MGSM2Fix.vcxproj
+++ b/MGSM2Fix.vcxproj
@@ -376,6 +376,9 @@
     <PostBuildEvent>
       <Command>python "$(ProjectDir)M2Install.py" "$(TargetPath)" $(LibrariesArchitecture)</Command>
     </PostBuildEvent>
+    <PreBuildEvent>
+      <Command>call "$(ProjectDir)build_zydis.cmd" $(Platform)</Command>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -407,6 +410,9 @@
     <PostBuildEvent>
       <Command>python "$(ProjectDir)M2Install.py" "$(TargetPath)" $(LibrariesArchitecture)</Command>
     </PostBuildEvent>
+    <PreBuildEvent>
+      <Command>call "$(ProjectDir)build_zydis.cmd" $(Platform)</Command>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -432,6 +438,9 @@
     <PostBuildEvent>
       <Command>python "$(ProjectDir)M2Install.py" "$(TargetPath)" $(LibrariesArchitecture)</Command>
     </PostBuildEvent>
+    <PreBuildEvent>
+      <Command>call "$(ProjectDir)build_zydis.cmd" $(Platform)</Command>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -463,6 +472,9 @@
     <PostBuildEvent>
       <Command>python "$(ProjectDir)M2Install.py" "$(TargetPath)" $(LibrariesArchitecture)</Command>
     </PostBuildEvent>
+    <PreBuildEvent>
+      <Command>call "$(ProjectDir)build_zydis.cmd" $(Platform)</Command>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/build_zydis.cmd
+++ b/build_zydis.cmd
@@ -1,0 +1,68 @@
+@echo off
+setlocal enabledelayedexpansion
+
+echo === Building Zydis if needed ===
+
+REM --- Detect platform (arg > env var > default x64) ---
+set "PLAT=%~1"
+if "%PLAT%"=="" set "PLAT=%Platform%"
+if "%PLAT%"=="" set "PLAT=x64"
+
+REM --- Locate Zydis project file ---
+set "ZY_PROJECT=%~dp0src\zydis\msvc\zydis\Zydis.vcxproj"
+if not exist %ZY_PROJECT% (
+    echo ERROR: Zydis project file not found at %ZY_PROJECT%
+    exit /b 1
+)
+
+REM --- Get current submodule commit hash ---
+pushd "%~dp0src\zydis" >nul
+for /f %%H in ('git rev-parse HEAD') do set "ZY_HASH=%%H"
+if not defined ZY_HASH (
+    echo ERROR: Could not read Zydis git hash. Is the submodule initialized?
+    popd >nul
+    exit /b 1
+)
+popd >nul
+
+REM --- Configure paths ---
+if /i "%PLAT%"=="x64" (
+    set "ZY_LIB=%~dp0src\zydis\msvc\bin\ReleaseX64\Zydis.lib"
+    set "HASH_FILE=%~dp0src\zydis\msvc\bin\ReleaseX64\.zydis_build_hash"
+    set "MSBUILD_ARGS=/p:Configuration="Release MT" /p:Platform=x64 /m /nologo /verbosity:minimal"
+) else if /i "%PLAT%"=="Win32" (
+    set "ZY_LIB=%~dp0src\zydis\msvc\bin\ReleaseX86\Zydis.lib"
+    set "HASH_FILE=%~dp0src\zydis\msvc\bin\ReleaseX86\.zydis_build_hash"
+    set "MSBUILD_ARGS=/p:Configuration="Release MT" /p:Platform=Win32 /m /nologo /verbosity:minimal"
+) else (
+    echo ERROR: Unsupported platform %PLAT%
+    endlocal
+    exit /b 1
+)
+
+REM --- Decide if rebuild is needed ---
+set "NEED_BUILD=0"
+if not exist "%ZY_LIB%" set "NEED_BUILD=1"
+if not exist "%HASH_FILE%" set "NEED_BUILD=1"
+
+if exist "%HASH_FILE%" (
+    set /p OLD_HASH=<"%HASH_FILE%"
+    if not "!OLD_HASH!"=="%ZY_HASH%" set "NEED_BUILD=1"
+)
+
+REM --- Build if needed ---
+if "%NEED_BUILD%"=="1" (
+    echo [Zydis] Building Release MT %PLAT%
+    msbuild %ZY_PROJECT% %MSBUILD_ARGS%
+    if errorlevel 1 (
+        echo ERROR: Zydis Release MT %PLAT% build failed
+        exit /b 1
+    )
+    >"%HASH_FILE%" echo %ZY_HASH%
+) else (
+    echo [Zydis] Release MT %PLAT% up to date, skipping
+)
+
+echo === Zydis build check complete ===
+endlocal
+exit /b 0


### PR DESCRIPTION
Port from the HDFix framework. Moves zydis out of the m2fix .sln to a pre-build event.

Ultimately no change outside of making the project only rebuild zydis if the git submodule gets updated (which also applies to the release/ci workflows), overall reducing compilation time.