### PR TITLE
Restricts imgui to only debug builds, resolving most antivirus false-positives (for real this time)

### DIFF
--- a/MGSM2Fix.vcxproj
+++ b/MGSM2Fix.vcxproj
@@ -356,7 +356,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;_DEBUG;MGSM2Fix_EXPORTS;_WINDOWS;_USRDLL;_DEBUG_DUMP;_CRT_SECURE_NO_WARNINGS;SPDLOG_COMPILED_LIB;%(PreprocessorDefinitions);ZYDIS_STATIC_BUILD;ZYCORE_STATIC_BUILD</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;MGSM2Fix_EXPORTS;_WINDOWS;_USRDLL;_DEBUG_DUMP;_CRT_SECURE_NO_WARNINGS;SPDLOG_COMPILED_LIB;%(PreprocessorDefinitions);ZYDIS_STATIC_BUILD;ZYCORE_STATIC_BUILD;M2FIX_USE_IMGUI</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -387,7 +387,7 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>.;src\inipp\inipp;src\spdlog\include;src\spdlog\include\spdlog;src\safetyhook;src\FunctionTraits;src\squirrel\include;src\squirrel\sqstdlib;src\squirrel\squirrel;src\squirrel\sqdbg;src\sqrat\include;src\sqrat\include\sqrat;src\imgui;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>.;src\inipp\inipp;src\spdlog\include;src\spdlog\include\spdlog;src\safetyhook;src\FunctionTraits;src\squirrel\include;src\squirrel\sqstdlib;src\squirrel\squirrel;src\squirrel\sqdbg;src\sqrat\include;src\sqrat\include\sqrat;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <Optimization>MinSpace</Optimization>
@@ -412,7 +412,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;MGSM2Fix_EXPORTS;_WINDOWS;_USRDLL;_DEBUG_DUMP;_CRT_SECURE_NO_WARNINGS;SPDLOG_COMPILED_LIB;%(PreprocessorDefinitions);ZYDIS_STATIC_BUILD;ZYCORE_STATIC_BUILD</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;MGSM2Fix_EXPORTS;_WINDOWS;_USRDLL;_DEBUG_DUMP;_CRT_SECURE_NO_WARNINGS;SPDLOG_COMPILED_LIB;%(PreprocessorDefinitions);ZYDIS_STATIC_BUILD;ZYCORE_STATIC_BUILD;M2FIX_USE_IMGUI</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -443,7 +443,7 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>.;src\inipp\inipp;src\spdlog\include;src\spdlog\include\spdlog;src\safetyhook;src\FunctionTraits;src\squirrel\include;src\squirrel\sqstdlib;src\squirrel\squirrel;src\squirrel\sqdbg;src\sqrat\include;src\sqrat\include\sqrat;src\imgui;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>.;src\inipp\inipp;src\spdlog\include;src\spdlog\include\spdlog;src\safetyhook;src\FunctionTraits;src\squirrel\include;src\squirrel\sqstdlib;src\squirrel\squirrel;src\squirrel\sqdbg;src\sqrat\include;src\sqrat\include\sqrat;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <Optimization>MinSpace</Optimization>

--- a/src/d3d11.cpp
+++ b/src/d3d11.cpp
@@ -5,9 +5,11 @@
 
 #include <d3dcompiler.h>
 
+#if defined(M2FIX_USE_IMGUI)
 #include "imgui.h"
 #include "backends/imgui_impl_win32.h"
 #include "backends/imgui_impl_dx11.h"
+#endif
 
 #include "resource.h"
 
@@ -1808,6 +1810,7 @@ void WINAPI D3D11::Deferred::DrawIndexed(
     );
 }
 
+#if defined(M2FIX_USE_IMGUI)
 BOOL WINAPI D3D11::ShowWindow(
     HWND hWnd,
     int  nCmdShow
@@ -1820,7 +1823,9 @@ BOOL WINAPI D3D11::ShowWindow(
         nCmdShow
     );
 }
+#endif
 
+#if defined(M2FIX_USE_IMGUI)
 void D3D11::Overlay(ID3D11DeviceContext *pContext)
 {
     if (!pContext && M2Config::bConsole) {
@@ -1923,6 +1928,7 @@ void D3D11::Overlay(ID3D11DeviceContext *pContext)
     upscalerDisabled = !upscalerEnabled;
     overlayDisabled = false;
 }
+#endif
 
 void WINAPI D3D11::DrawIndexed(
     void (WINAPI *pFunction)(
@@ -1952,7 +1958,9 @@ void WINAPI D3D11::DrawIndexed(
         );
     }
 
+#if defined(M2FIX_USE_IMGUI)
     Overlay(pContext);
+#endif
 }
 
 HRESULT WINAPI D3D11::Immediate::FinishCommandList(
@@ -2194,7 +2202,10 @@ HRESULT WINAPI D3D11::CreateDevice(
 void D3D11::Load()
 {
     Upscale(nullptr);
+
+#if defined(M2FIX_USE_IMGUI)
     Overlay(nullptr);
+#endif
 
     HMODULE d3d11 = LoadLibraryA("d3d11.dll");
     if (!d3d11) {

--- a/src/d3d11.h
+++ b/src/d3d11.h
@@ -21,13 +21,16 @@ public:
 
 private:
 	static void Upscale(ID3D11DeviceContext *pContext);
+#if defined(M2FIX_USE_IMGUI)
 	static void Overlay(ID3D11DeviceContext *pContext);
+#endif
 
+#if defined(M2FIX_USE_IMGUI)
 	static BOOL WINAPI ShowWindow(
 		HWND hWnd,
 		int  nCmdShow
 	);
-
+#endif
 	class Immediate {
 	public:
 		static void WINAPI UpdateSubresource(


### PR DESCRIPTION
machine learning antivirus algos are a fucking blight.
Closes #70

before
<img width="1326" height="189" alt="455233815-11a257e8-290f-407b-b840-5b2cd2a273c8" src="https://github.com/user-attachments/assets/aef7e216-1414-4f43-b6e9-cb59d0719770" />

after
<img width="1185" height="1782" alt="image" src="https://github.com/user-attachments/assets/b597ca2b-0028-434c-8212-8a47a316e7f5" />


