### PR TITLE
Adds a config option to disable windows fullscreen optimization, fixing main menu corruption issue

### DIFF
--- a/MGSM2Fix.ini
+++ b/MGSM2Fix.ini
@@ -21,6 +21,13 @@ Enabled = false
 Height = 0
 Widescreen = false
 
+[Fixes]
+; System specific fix: If your game's main menu shows graphical corruption,
+; Enable this to force Windows compatibility settings to disable Fullscreen Optimization.
+; This writes to HKEY_CURRENT_USER\Software\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers
+; Equivalent to: right click the game's .exe -> Properties -> Compatibility -> "Disable Fullscreen Optimizations"
+DisableWindowsFullscreenOptimization = false
+
 [Launcher]
 ; Skips the warnings / logos on start.
 SkipNotice = true

--- a/src/m2config.cpp
+++ b/src/m2config.cpp
@@ -101,6 +101,8 @@ void M2Config::Load()
     inipp::get_value(ini.sections["Update Notifications"], "CheckForUpdates", bShouldCheckForUpdates);
     inipp::get_value(ini.sections["Update Notifications"], "ConsoleNotifications", bConsoleUpdateNotifications);
 
+    inipp::get_value(ini.sections["Fixes"], "DisableWindowsFullscreenOptimization", bDisableWindowsFullscreenOptimization);
+
 
 
     // Force windowed mode if borderless is enabled but windowed is not.
@@ -159,6 +161,7 @@ void M2Config::Load()
     spdlog::info("[Config] bGameStageSelect: {}", bGameStageSelect);
     spdlog::info("[Config] bShouldCheckForUpdates: {}", bShouldCheckForUpdates);
     spdlog::info("[Config] bConsoleUpdateNotifications: {}", bConsoleUpdateNotifications);
+    spdlog::info("[Config] bDisableWindowsFullscreenOptimization: {}", bDisableWindowsFullscreenOptimization);
 
     if (bDebuggerEnabled && bDebuggerExclusive)
     {

--- a/src/m2config.h
+++ b/src/m2config.h
@@ -63,6 +63,7 @@ public:
     static inline bool bPatchesRestoreMedicine;
     static inline bool bShouldCheckForUpdates;
     static inline bool bConsoleUpdateNotifications;
+    static inline bool bDisableWindowsFullscreenOptimization;
 
     static inline std::string sFullscreenMode;
     static inline std::string sExternalWidth;

--- a/src/m2utils.cpp
+++ b/src/m2utils.cpp
@@ -7,10 +7,19 @@
 
 bool M2Utils::IsSteamOS()
 {
+    static bool bCheckedSteamDeck = false;
+    static bool bIsSteamDeck = false;
+    if (bCheckedSteamDeck)
+    {
+        return bIsSteamDeck;
+    }
+    bCheckedSteamDeck = true;
     // Check for Proton/Steam Deck environment variables
-    return std::getenv("STEAM_COMPAT_CLIENT_INSTALL_PATH") ||
-        std::getenv("STEAM_COMPAT_DATA_PATH") ||
-        std::getenv("XDG_SESSION_TYPE"); 
+    if (std::getenv("STEAM_COMPAT_CLIENT_INSTALL_PATH") || std::getenv("STEAM_COMPAT_DATA_PATH") || std::getenv("XDG_SESSION_TYPE"))
+    {
+        bIsSteamDeck = true;
+    }
+    return bIsSteamDeck;
 }
 
 std::string M2Utils::GetSteamOSVersion()

--- a/src/mgs1.h
+++ b/src/mgs1.h
@@ -7,6 +7,7 @@
 #include "psx.h"
 #include "analog.h"
 #include "d3d11.h"
+#include "m2utils.h"
 
 #include "sqhook.h"
 
@@ -32,6 +33,11 @@ public:
     virtual void Load() override
     {
         D3D11::LoadInstance();
+
+        if (M2Config::bDisableWindowsFullscreenOptimization && !M2Utils::IsSteamOS())
+        {
+            DisableWindowsFullscreenOptimization();
+        }
 
         if (M2Config::bAnalogMode) {
             Analog::LoadInstance();
@@ -113,6 +119,8 @@ private:
     uintptr_t MGS1_LoaderPTR = 0;
 
     int MGS1_Blank = 0;
+
+    static void DisableWindowsFullscreenOptimization();
 
     const std::vector<std::string> MGS1_FileFilter_Underpants = {
         "0046a5", "0046a6",


### PR DESCRIPTION
Closes #73
Closes #76
Closes #72
Closes #46
Closes #55

before
<img width="540" height="699" alt="image" src="https://github.com/user-attachments/assets/1da63dba-4c02-4047-9aec-bb02d07dccba" />


after
```
[2025-09-15 11:50:36.921] [MGSM2Fix] [info] [Registry Compat Fix] Checking registry for METAL GEAR SOLID.exe compatibility flags.
[2025-09-15 11:50:36.921] [MGSM2Fix] [info] [Registry Compat Fix] Created registry entry for G:\Steam\steamapps\common\MGS1\METAL GEAR SOLID.exe with value: ~ DISABLEDXMAXIMIZEDWINDOWEDMODE
```

<img width="540" height="699" alt="2025-09-15_11-50-46-explorer-METAL_GEAR_SOLID exe_Properties" src="https://github.com/user-attachments/assets/db976b2c-6d31-495f-8122-0a9e534d97b3" />

If the key already exists with `DISABLEDXMAXIMIZEDWINDOWEDMODE`, do nothing

```
[2025-09-15 11:51:30.584] [MGSM2Fix] [info] [Registry Compat Fix] Checking registry for METAL GEAR SOLID.exe compatibility flags.
[2025-09-15 11:51:30.584] [MGSM2Fix] [info] [Registry Compat Fix] Registry entry for G:\Steam\steamapps\common\MGS1\METAL GEAR SOLID.exe already contains: ~ DISABLEDXMAXIMIZEDWINDOWEDMODE
```

If the key already exists but doesn't have `DISABLEDXMAXIMIZEDWINDOWEDMODE`, append it
```
[2025-09-15 11:52:06.076] [MGSM2Fix] [info] [Registry Compat Fix] Checking registry for METAL GEAR SOLID.exe compatibility flags.
[2025-09-15 11:52:06.076] [MGSM2Fix] [info] [Registry Compat Fix] Updated registry entry for G:\Steam\steamapps\common\MGS1\METAL GEAR SOLID.exe: ~ HIGHDPIAWARE DISABLEDXMAXIMIZEDWINDOWEDMODE
```



