### PR TITLE
makes logging asynchronous

### DIFF
--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -25,18 +25,13 @@ void Main(HINSTANCE hinstDLL)
 
 BOOL APIENTRY DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 {
-    switch (fdwReason)
+    if (fdwReason == DLL_PROCESS_ATTACH)
     {
-        case DLL_PROCESS_ATTACH:
-        {
-            Main(hinstDLL);
-            break;
-        }
-
-        case DLL_THREAD_ATTACH:
-        case DLL_THREAD_DETACH:
-        case DLL_PROCESS_DETACH:
-            break;
+        Main(hinstDLL);
+    }
+    else if (fdwReason == DLL_PROCESS_DETACH)
+    {
+        spdlog::shutdown();
     }
 
     return TRUE;

--- a/src/m2fix.h
+++ b/src/m2fix.h
@@ -132,7 +132,9 @@ public:
         auto path = M2Hook::GetInstance().ModuleLocation().parent_path();
 
         try {
-            auto logger = spdlog::basic_logger_mt(FixName(), (path / LogFile()).string(), true);
+            spdlog::init_thread_pool(8192, 1);
+            auto sink = std::make_shared<spdlog::sinks::basic_file_sink_mt>((path / LogFile()).string(), true);
+            auto logger = std::make_shared<spdlog::async_logger>(FixName(), sink, spdlog::thread_pool(), spdlog::async_overflow_policy::block);
             spdlog::set_default_logger(logger);
         }
         catch (const spdlog::spdlog_ex & ex) {

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -55,6 +55,7 @@ using namespace StdExt;
 
 #include "inipp.h"
 #include "spdlog.h"
+#include "async.h"
 #include "spdlog/sinks/basic_file_sink.h"
 #include "spdlog/sinks/stdout_sinks.h"
 #include "spdlog/sinks/wincolor_sink.h"


### PR DESCRIPTION
seems to improve performance a little when logging hot stuff (ie squirrel stuff), although it's not a perfect solution / still chokes on directx logging. i looked into the spdlog flush delay function and it doesn't seem to work - so this seems to be the best we have for now.