### PR TITLE
Fix in thread.call

### DIFF
--- a/src/squirrel/squirrel/sqbaselib.cpp
+++ b/src/squirrel/squirrel/sqbaselib.cpp
@@ -833,6 +833,7 @@ static SQInteger thread_call(HSQUIRRELVM<Q> v)
 	SQObjectPtr o = stack_get(v,1);
 	if(obj_type(o) == OT_THREAD) {
 		SQInteger nparams = sq_gettop(v);
+		sq_reservestack(_thread(o), nparams + 3);
 		_thread(o)->Push(_thread(o)->_roottable);
 		for(SQInteger i = 2; i<(nparams+1); i++)
 			sq_move(_thread(o),v,i);


### PR DESCRIPTION
This PR fixes a potential security vulnerability in thread_call that was cloned from https://github.com/albertodemichelis/squirrel but did not receive the security patch.

### Details:
Affected Function: thread_call in src/squirrel/squirrel/sqbaselib.cpp
Original Fix: https://github.com/albertodemichelis/squirrel/commit/a6413aa690e0bdfef648c68693349a7b878fe60d

### What this PR does:
This PR applies the same security patch that was applied to the original repository to eliminate the potential vulnerability in the cloned code.

### References:
- https://github.com/albertodemichelis/squirrel/commit/a6413aa690e0bdfef648c68693349a7b878fe60d
- https://nvd.nist.gov/vuln/detail/CVE-2022-30292

Please review and merge this PR to ensure your repository is protected against this potential vulnerability.
