### PR TITLE
Fixes Contra collection detection failure

### DIFF
--- a/src/m2fix.h
+++ b/src/m2fix.h
@@ -348,7 +348,7 @@ private:
     std::multimap<M2FixGame, M2FixInfo> m_kGames = {
         { M2FixGame::MGS1,               { 2131630, "MGS1",                           "", MGS1::GetInstance()   } },
         { M2FixGame::MGSR,               { 2306740, "MGSBC",                          "", M2Game::GetInstance() } },
-        { M2FixGame::Contra,             { 1018020, "CONTRALLECTION",                 "", M2Game::GetInstance() } },
+        { M2FixGame::Contra,             { 1018020, "CONTRACOLLECTION",               "", M2Game::GetInstance() } },
         { M2FixGame::Dracula,            { 1018010, "CASTLEVANIACOLLECTION",          "", M2Game::GetInstance() } },
         { M2FixGame::DraculaAdvance,     { 1552550, "CASTLEVANIAADVANCECOLLECTION",   "", M2Game::GetInstance() } },
         { M2FixGame::DraculaDominus,     { 2369900, "CASTLEVANIADOMINUSCOLLECTION",   "", M2Game::GetInstance() } },


### PR DESCRIPTION
smol typo - fixes an issue described in #43

```
[2026-02-21 03:28:01.480] [MGSM2Fix] [info] ----------
[2026-02-21 03:28:01.480] [MGSM2Fix] [info] [Module] Name: game.exe
[2026-02-21 03:28:01.480] [MGSM2Fix] [info] [Module] Path: T:\SteamLibrary\steamapps\common\Contra Anniversary Collection\game.exe
[2026-02-21 03:28:01.480] [MGSM2Fix] [info] [Module] Address: 0xe80000
[2026-02-21 03:28:01.480] [MGSM2Fix] [info] [Module] Timestamp: 2019-05-31 (1559277284)
[2026-02-21 03:28:01.480] [MGSM2Fix] [info] ----------
[2026-02-21 03:28:01.623] [MGSM2Fix] [critical] Failed to detect supported game, Contra Anniversary Collection\game.exe isn't supported by MGSM2Fix.
```